### PR TITLE
Typescript cleanup

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,7 @@ import cfg from '../config/config.json' assert { type: "json" };
 
 type output = {
   log: Logger
-  filename: String,
+  filename: string,
   stream: WriteStream
 }
 

--- a/src/util/logger.ts
+++ b/src/util/logger.ts
@@ -15,7 +15,7 @@ export class Logger {
     }
   }
 
-  getSource = (trace: String | void) => {
+  getSource = (trace: string | void) => {
     if (typeof trace === `string`) {
       const match = trace.split(`\n`)[2].match(/(?<=at\s|\()([^(]*):(\d+):(\d+)\)?$/);
   
@@ -31,7 +31,7 @@ export class Logger {
     return `unknown`;
   }
 
-  format = (content: any, level: String, source: String | void) => {
+  format = (content: any, level: string, source: string | void) => {
     const now = new Date();
     const hh = now.getUTCHours().toString().padStart(2, `0`);
     const mm = now.getUTCMinutes().toString().padStart(2, `0`);

--- a/src/util/logger.ts
+++ b/src/util/logger.ts
@@ -7,7 +7,7 @@ import { WriteStream } from 'fs';
 export class Logger {
   stream: WriteStream | null;
 
-  constructor(stream: WriteStream | void) {
+  constructor(stream?: WriteStream) {
     if (stream != null) {
       this.stream = stream;
     } else {
@@ -15,7 +15,7 @@ export class Logger {
     }
   }
 
-  getSource = (trace: string | void) => {
+  getSource = (trace?: string) => {
     if (typeof trace === `string`) {
       const match = trace.split(`\n`)[2].match(/(?<=at\s|\()([^(]*):(\d+):(\d+)\)?$/);
   
@@ -31,7 +31,7 @@ export class Logger {
     return `unknown`;
   }
 
-  format = (content: any, level: string, source: string | void) => {
+  format = (content: any, level: string, source?: string) => {
     const now = new Date();
     const hh = now.getUTCHours().toString().padStart(2, `0`);
     const mm = now.getUTCMinutes().toString().padStart(2, `0`);


### PR DESCRIPTION
Just a few things to get you started:

• The `String` type (as in, the String object) is rarely used in comparison to the `string` primitive. You'll want to use the `string` primitive in pretty much every case. See other: https://stackoverflow.com/questions/14727044/what-is-the-difference-between-types-string-and-string
• Any time you want to make a parameter optional, add a `?` after it. For example, your `format` method in the logger class: `format = (content: any, level: string, source?: string`. Easier readability, and nobody really uses `void` outside of declaring what a function returns, not a parameter (that I've seen).